### PR TITLE
chore: add section about CARs to readme & clarify root CID vs CAR CID

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,21 @@ Commands:
   w3up register <email>                   Register your UCAN Identity with w3up
   w3up whoami                             Show your current UCAN Identity
   w3up list                               List your uploads
-  w3up upload <path>                      Upload a file or directory to your acc
-                                          ount                 [aliases: import]
+  w3up upload <path>                      Upload any file or directory to your a
+                                          ccount               [aliases: import]
+  w3up upload-cars <path>                 Walk a file directory, and upload any
+                                          found cars to an account
   w3up remove <cid>                       Unlink a CID from your account.
                                                                [aliases: unlink]
   w3up import-settings <fileName>         Import a settings.json file
   w3up export-settings [filename]         Export a settings json file
   w3up reset-settings                     Delete all local settings
   w3up insights <cid>                     Get insights for a CID
-  w3up car-to-dot <path>                  Generate an examination file from a <p
+  w3up inspect-car <path>                 Generate an examination file from a <p
                                           ath> to a CAR
   w3up generate-car <filePath> [outPath]  From an input file, locally generate a
                                            CAR file.
+  w3up info                               Print information about cli
 
 Options:
   --version  Show version number                                       [boolean]
@@ -104,9 +107,17 @@ Examples:
   w3up list                               bafy...
                                           bafy...
   w3up upload ../../duck.png              uploaded bafy...
+  w3up upload-cars ducks/                 <show all cars uploaded>
   w3up remove bafy...                     unlinked bafy...
-  w3up car-to-dot ../duck.car             generated examination file
-  w3up generate-car ../duck.png duck.car  CAR created ../duck.png => duck.ca
+  w3up inspect-car ../duck.car --tree     roots
+                                          └─┬ bafy...
+                                            └── duck.png
+  w3up generate-car ../duck.png duck.car  CAR created ../duck.png => duck.car
+  w3up info
+
+Docs:
+  https://github.com/nftstorage/w3up-cli
+
 ```
 
 
@@ -169,15 +180,47 @@ After creating your identity and registering with w3up, you should be able to st
 
 #### `upload`
 
+> Uploads a file or directory and links it to your account.
+
 ```sh
 w3up upload <filename>
 ```
 
-Uploads a file or directory and link it to your account. The second argument is the path to that file or directory.
-
 **Important:** All data uploaded using `w3up` is made available to anyone who requests it using the correct [CID][concepts-cid]. Do not upload sensitive or private data in unencrypted form!
 
+The example below uploads a file named `test.txt` containing the text `hello world`:
+
+```sh
+w3up upload test.txt
+```
+
+You should see something like this:
+
+```
+✔ Succeeded uploading bagbaieraq7mqnbxwetsl53fs776rcink4ar6ow5u5imrb3di6klochw2fdfq with 200: OK
+roots:
+ bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi
+```
+
+Notice that there are two [CIDs][concepts-cid] printed in the output. The first CID identifies the [Content Archive (CAR)](#about-content-archives-cars) that `w3up` generates when preparing your files for upload. 
+
+A CAR is a collection of content-addressed data "block", with one or more "root blocks" that contain data and/or links to other blocks. In the output above, there's a single root block with the CID `bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi`. This root CID is what you want to use when retrieving data from IPFS. For example, to fetch the file from the HTTP gateway at `w3s.link`, you would use the URL https://w3s.link/ipfs/bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi
+
+
 > 📝 If you are uploading thousands of small files, it's faster to put them together into a directory and upload that, than to invoke this CLI with thousands of individual files.
+
+#### `upload-cars`
+
+> Upload a CAR file (content archive) containing IPLD data.
+
+The [`upload`](#upload) command described above accepts regular files and directories and packs them into a [Content Archive (CAR)](#about-content-archives-cars) before uploading to the web3.storage platform. If you already have your data in CAR format, of if you'd rather do the CAR conversion yourself, you can use the `upload-cars` command.
+
+```sh
+w3up upload-cars <path>
+```
+
+The `path` argument must point to a directory containing one or more CAR files. If there are nested directories, each will be recursively walked and all discovered CAR files will be uploaded.
+
 
 #### `list`
 
@@ -186,6 +229,16 @@ Uploads a file or directory and link it to your account. The second argument is 
 ```sh
 w3up list
 ```
+
+You should see something similar to this:
+
+```
+✔ Listing Uploads...
+✔ CIDs:
+bagbaieraq7mqnbxwetsl53fs776rcink4ar6ow5u5imrb3di6klochw2fdfq
+```
+
+Note that `list` currently shows the CID of the [Content Archive (CAR)](#about-content-archives-cars) that was uploaded and does not yet include the root CID of the content graph within the CAR.
 
 #### `remove`
 
@@ -198,6 +251,62 @@ w3up remove <cid>
 This will dis-associate an uploaded asset from your account. If you run `w3up list` after unlinking a file, you should not see it in the list. If you want to re-associate the file with your account, use `w3up upload` and re-upload the file. In situations when a file has been previously uploaded, the upload command will not need to actually upload the file, it will just relink it.
 
 **Important:** `w3up remove` does not delete your data from the public IPFS network, Filecoin, or other decentralized storage systems used by w3up. Data that has been `remove`d and is not linked to any other accounts _may_ eventually be deleted from the internal storage systems used by the w3up service, but there are no guarantees about when (or whether) that will occur, and you should not depend on data being permanently deleted.
+
+### CAR file commands
+
+When using [`w3up upload`](#upload), your files are packed into a [Content Archive (CAR)](#about-content-archives-cars), which efficiently stores content-addressed blocks of data. In some cases, you may want to [upload CARs directly](#upload-cars), skipping the automatic conversion. For example, you may want to bulk-convert a large dataset into CAR format before upload to preserve a local backup of your data in CAR format.
+
+`w3up` provides some commands for creating and working with CAR files. For more, see the [guide to working with Content Archives](https://web3.storage/docs/how-tos/work-with-car-files/) in the [Web3.Storage docs](https://web3.storage/docs).
+
+#### `generate-car`
+
+> Encodes a file or directory to CAR format.
+
+The `generate-car` command accepts a path to a file or directory and creates a CAR file that can be uploaded with [`upload-cars`](#upload-cars).
+
+```sh
+w3up generate-car test.txt
+```
+
+```
+✔ CAR created test.txt => bagbaieraq7mqnbxwetsl53fs776rcink4ar6ow5u5imrb3di6klochw2fdfq.car
+roots:
+ bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi
+```
+
+As with the [`upload` command](#upload), two CIDs are printed in the `generate-car` output. The first CID is for the CAR file itself, while the root CID identifies the content within the CAR. Use the root CID when requesting content from IPFS, e.g. with `ipfs get` or from an HTTP gateway.
+
+#### `inspect-car`
+
+> Print the CID of all blocks in a CAR file.
+
+The `inspect-car` command takes the path to a CAR file and prints the CID of each block contained in the CAR.
+
+```sh
+w3up inspect-car test.car
+```
+
+```
+CIDv1								                                        CIDv0
+bafybeicg2rebjoofv4kbyovkw7af3rpiitvnl6i7ckcywaq6xjcxnc2mby	zQmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o
+bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi	zQmd8DcmhjnfSBMLM7f9q3puvFuUgBjHiXeVZNHWh5ZWwjX
+```
+
+Note that each CID is printed twice, once in the current CID version 1 format, and once in the deprecated "v0" format. We strongly recommend using CIDv1 wherever possible, but the v0 CID may be useful for integration with existing systems.
+
+You can also see the tree structure of the CAR file by passing in the `--tree` flag to `inspect-car`:
+
+```sh
+w3up inspect-car --tree test.car
+```
+
+```
+roots
+└─┬ bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi
+  └── test.txt
+```
+
+Finally, passing the `--dot` flag will output a description of the graph structure using the [DOT](https://graphviz.org/doc/info/lang.html) language defined by the [Graphviz](https://graphviz.org/) project, to allow visually inspecting the CAR structure.
 
 ### Settings management
 
@@ -239,6 +348,15 @@ w3up insights <cid>
 `w3up insights <cid>` will hit the w3up service and retrieve all currently known insights for that CID. 
 
 The `w3up insights-ws` is similar, but will set up a websockets-based watch and print any further insights as they are discovered.
+
+
+## About Content Archives (CARs)
+
+Under the hood, `w3up` always uploads data in the form of Content ARchives, or CARs. The [CAR format](https://ipld.io/specs/transport/car/) allows efficiently transmitting a collection of content-addressed blocks of data.
+
+If you're using the [`upload` command](#upload), this should be relatively transparent, although you may notice that the command output shows the CID of the CAR as well as the CID of the content. If you're [uploading CARs directly](#upload-cars), you may also want to use the `w3up` commands for [working with CAR files](#car-file-commands).
+
+You can find more information about working with CAR files in the [guide to working with CARs](https://web3.storage/docs/how-tos/work-with-car-files/) in the [Web3.Storage docs](https://web3.storage/docs).
 
 ## Run tests
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ roots:
 
 Notice that there are two [CIDs][concepts-cid] printed in the output. The first CID identifies the [Content Archive (CAR)](#about-content-archives-cars) that `w3up` generates when preparing your files for upload. 
 
-A CAR is a collection of content-addressed data "block", with one or more "root blocks" that contain data and/or links to other blocks. In the output above, there's a single root block with the CID `bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi`. This root CID is what you want to use when retrieving data from IPFS. For example, to fetch the file from the HTTP gateway at `w3s.link`, you would use the URL https://w3s.link/ipfs/bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi
+A CAR is a collection of content-addressed data "blocks", with one or more "root blocks" that contain data and/or links to other blocks. In the output above, there's a single root block with the CID `bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi`. This root CID is what you want to use when retrieving data from IPFS. For example, to fetch the file from the HTTP gateway at `w3s.link`, you would use the URL https://w3s.link/ipfs/bafybeig3v73gypy3wshzjdq6aopisk66hjdwdma4cg6q7eojiuhivorkyi
 
 
 > 📝 If you are uploading thousands of small files, it's faster to put them together into a directory and upload that, than to invoke this CLI with thousands of individual files.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ A CAR is a collection of content-addressed data "blocks", with one or more "root
 
 #### `upload-cars`
 
-> Upload a CAR file (content archive) containing IPLD data.
+> Bulk upload a collection of  CAR files (content archives) containing IPLD data.
 
 The [`upload`](#upload) command described above accepts regular files and directories and packs them into a [Content Archive (CAR)](#about-content-archives-cars) before uploading to the web3.storage platform. If you already have your data in CAR format, of if you'd rather do the CAR conversion yourself, you can use the `upload-cars` command.
 


### PR DESCRIPTION
This adds a note to the `upload` command docs about the difference between the CAR CID and the root CID of the content inside. 

I also added an "about CARs" section that links out to the web3.storage docs about cars and added the `upload-cars`, `generate-car` and `inspect-car` commands to the README.

Also updates the example `w3up --help` output with the latest.