### PR TITLE
fix: import delegation alias

### DIFF
--- a/src/commands/importDelegation.js
+++ b/src/commands/importDelegation.js
@@ -20,7 +20,7 @@ const exe = async ({ fileName, alias = '' }) => {
   if (fileName) {
     try {
       const bytes = await fs.promises.readFile(fileName)
-      const imported = await client.importDelegation(bytes)
+      const imported = await client.importDelegation(bytes, alias)
       const did = imported?.issuer?.did()
 
       view.succeed(

--- a/src/commands/switchAccount.js
+++ b/src/commands/switchAccount.js
@@ -35,8 +35,9 @@ const exe = async ({ did, alias }) => {
   if (alias) {
     const found = choices.find((x) => x.alias == alias)
     if (found) {
-      const del = settings.set('delegation', found || null)
-      console.log(`now using account: ${del?.issuer?.did()}`)
+      const del = found.value
+      settings.set('delegation', del)
+      console.log(`now using account: ${del}`)
     } else {
       console.log(
         `No account with alias ${alias} found. Here are your current accounts:\n`


### PR DESCRIPTION
Fixes alias for:
- Import delegation alias was not being passed to client https://github.com/web3-storage/w3up-client/blob/v2.1.1/src/index.js#L356
- switch-account alias was not being set properly like in the `inquirerPick`

```sh
➜  w3up-cli git:(fix/import-delegation-alias) ✗ node src/cli.js import-delegation delegation.car testalias
✔ Imported delegation for testalias did:key:z6Mks2n8XVoqhhXyArKx7WxxCFPEWxJEcp5HERr7pW2KzLWU from delegation.car successfully.

➜  w3up-cli git:(fix/import-delegation-alias) ✗ node src/cli.js accounts
selected   alias       did
--------   --------    --------
*          self        did:key:z6Mkej48TJxzikp94tknz2pjJ5fc8AMjaicWLkn6wPLSFhvZ
           testalias   did:key:z6Mks2n8XVoqhhXyArKx7WxxCFPEWxJEcp5HERr7pW2KzLWU

➜  w3up-cli git:(fix/import-delegation-alias) ✗ node src/cli.js switch-account testalias
now using account: did:key:z6Mks2n8XVoqhhXyArKx7WxxCFPEWxJEcp5HERr7pW2KzLWU

➜  w3up-cli git:(fix/import-delegation-alias) ✗ node src/cli.js list
✔ Listing Uploads...
Date        Data CID
--------    --------
10/4/2022   bafybeifpnwjt6jl43yttpo64lhvbvfyepqsoj2cpoxaami6rk3x4kuwcty
```