### PR TITLE
Pretter: Standardjs formatting and fixing

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,10 +1,1 @@
-module.exports = {
-  trailingComma: 'es5',
-  endOfLine: 'lf',
-  tabWidth: 2,
-  semi: false,
-  singleQuote: true,
-  importOrder: ['^[./]'],
-  importOrderSeparation: true,
-  importOrderSortSpecifiers: true,
-}
+module.exports = 'prettier-config-standard'

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "chai-subset": "^1.6.0",
     "mocha": "^10.0.0",
     "prettier": "^2.7.1",
+    "prettier-config-standard": "^5.0.0",
     "semantic-release": "^19.0.5",
     "typescript": "^4.7.4",
     "vitest": "^0.23.2"

--- a/src/client.js
+++ b/src/client.js
@@ -1,8 +1,7 @@
+import { default as cliSettings } from './settings.js'
 import * as CBOR from '@ucanto/transport/cbor'
 import W3Client from '@web3-storage/w3up-client'
 import Conf from 'conf'
-
-import { default as cliSettings } from './settings.js'
 
 const serialize = ({ ...data }) =>
   Buffer.from(CBOR.codec.encode(data)).toString('binary')
@@ -25,7 +24,7 @@ function mergeSettings(profileSettings) {
     projectName: cliSettings.projectName,
     fileExtension: 'cbor',
     serialize,
-    deserialize,
+    deserialize
   })
 
   if (oldSettings.size) {
@@ -41,7 +40,7 @@ export function getProfileSettings(profile = 'main') {
     configName: profile,
     fileExtension: 'cbor',
     serialize,
-    deserialize,
+    deserialize
   })
 
   // TODO: remove this when no longer needed.
@@ -60,7 +59,7 @@ export function getClient(profile = 'main') {
     // @ts-expect-error
     accessDID: cliSettings.ACCESS_DID,
     accessURL: cliSettings.ACCESS_URL,
-    settings,
+    settings
   })
 
   return client

--- a/src/commands/car/generate.js
+++ b/src/commands/car/generate.js
@@ -1,3 +1,8 @@
+import { buildCar } from '../../lib/car/buildCar.js'
+import { logToFile } from '../../lib/logging.js'
+import { MAX_CAR_SIZE } from '../../settings.js'
+import { bytesToCarCID } from '../../utils.js'
+import { isPath, resolvePath } from '../../validation.js'
 import fs from 'fs'
 // @ts-ignore
 import { CID } from 'multiformats/cid'
@@ -5,12 +10,6 @@ import ora from 'ora'
 import path from 'path'
 // @ts-ignore
 import toIterator from 'stream-to-it'
-
-import { buildCar } from '../../lib/car/buildCar.js'
-import { logToFile } from '../../lib/logging.js'
-import { MAX_CAR_SIZE } from '../../settings.js'
-import { bytesToCarCID } from '../../utils.js'
-import { isPath, resolvePath } from '../../validation.js'
 
 /**
  * @typedef {object} GenerateCar
@@ -27,7 +26,7 @@ import { isPath, resolvePath } from '../../validation.js'
  */
 export const writeFileLocally = async (car, outPath = 'output.car') => {
   return fs.promises.writeFile(resolvePath(outPath), car, {
-    encoding: 'binary',
+    encoding: 'binary'
   })
 }
 
@@ -42,7 +41,7 @@ const handler = async ({ filePath = '', split = false }) => {
   /** @type import('ora').Options */
   const oraOpts = {
     text: `Generating Car from ${resolvedPath}`,
-    spinner: 'line',
+    spinner: 'line'
   }
   const view = ora(oraOpts).start()
 
@@ -89,7 +88,7 @@ const builder = (yargs) =>
     type: 'boolean',
     alias: 'split',
     showInHelp: true,
-    describe: 'Split the data into multiple when cars when size limit is hit.',
+    describe: 'Split the data into multiple when cars when size limit is hit.'
   })
 
 /**
@@ -103,5 +102,5 @@ export default {
   builder,
   handler,
   exampleIn: '$0 generate-car ../duck.png duck.car',
-  exampleOut: `CAR created ../duck.png => duck.car`,
+  exampleOut: `CAR created ../duck.png => duck.car`
 }

--- a/src/commands/car/index.js
+++ b/src/commands/car/index.js
@@ -6,5 +6,5 @@ export default {
   describe: 'CAR file specific commands',
   // @ts-expect-error
   builder: (yargs) => yargs.command([generate, inspect]),
-  handler: () => {},
+  handler: () => {}
 }

--- a/src/commands/car/inspect.js
+++ b/src/commands/car/inspect.js
@@ -1,9 +1,8 @@
-import fs from 'fs'
-
 import { run as carToDot } from '../../lib/info/carToDot.js'
 import { run as carToList } from '../../lib/info/carToList.js'
 import { run as carToTree } from '../../lib/info/carToTree.js'
 import { isPath, resolvePath } from '../../validation.js'
+import fs from 'fs'
 
 /**
  * @typedef {{path?:string, dot?:boolean, vertical?:boolean}} CarInfo
@@ -20,7 +19,7 @@ const handler = async ({
   path = '/',
   dot = false,
   vertical = false,
-  tree = false,
+  tree = false
 }) => {
   const buffer = fs.readFileSync(resolvePath(path))
 
@@ -41,17 +40,17 @@ const builder = (yargs) =>
     .option('tree', {
       type: 'boolean',
       showInHelp: true,
-      describe: 'output the car as a tree on the command line',
+      describe: 'output the car as a tree on the command line'
     })
     .option('dot', {
       type: 'boolean',
       showInHelp: true,
-      describe: 'output the car as a DOT graph.',
+      describe: 'output the car as a DOT graph.'
     })
     .option('vertical', {
       type: 'boolean',
       showInHelp: true,
-      describe: 'set rankdir LR',
+      describe: 'set rankdir LR'
     })
 
 /**
@@ -67,5 +66,5 @@ export default {
   exampleIn: '$0 inspect-car ../duck.car --tree',
   exampleOut: `roots
 └─┬ bafy...
-  └── duck.png`,
+  └── duck.png`
 }

--- a/src/commands/delegations/import.js
+++ b/src/commands/delegations/import.js
@@ -1,8 +1,7 @@
-import fs from 'fs'
-import ora from 'ora'
-
 import { getClient } from '../../client.js'
 import { hasID, isPath } from '../../validation.js'
+import fs from 'fs'
+import ora from 'ora'
 
 /**
  * @typedef {{fileName?:string, alias?:string, profile?: string}} ImportDelegation
@@ -50,5 +49,5 @@ export default {
   describe:
     'Import a delegation.car file for access to an account (and give it an optional alias).',
   builder,
-  handler,
+  handler
 }

--- a/src/commands/delegations/index.js
+++ b/src/commands/delegations/index.js
@@ -13,6 +13,6 @@ export default {
       createDelegation,
       importDelegation,
       listDelegations,
-      switchDelegation,
-    ]),
+      switchDelegation
+    ])
 }

--- a/src/commands/delegations/list.js
+++ b/src/commands/delegations/list.js
@@ -1,8 +1,7 @@
 // @ts-ignore
-import { Delegation, UCAN } from '@ucanto/server'
-
 import { getClient } from '../../client.js'
 import { buildSimpleConsoleTable } from '../../utils.js'
+import { Delegation, UCAN } from '@ucanto/server'
 
 /**
  * @typedef {{ profile?: string }} ListAccounts
@@ -38,5 +37,5 @@ export default {
   command: 'list',
   describe: 'List all delegations (including from account to self).',
   builder,
-  handler,
+  handler
 }

--- a/src/commands/delegations/switch.js
+++ b/src/commands/delegations/switch.js
@@ -1,10 +1,9 @@
 // @ts-ignore
-import { Delegation } from '@ucanto/server'
-import inquirer from 'inquirer'
-
 import { getClient } from '../../client.js'
 import { hasID } from '../../validation.js'
 import listAccounts from './list.js'
+import { Delegation } from '@ucanto/server'
+import inquirer from 'inquirer'
 
 /**
  * @typedef {{did?:string, alias?:string, profile?: string}} SwitchAccounts
@@ -30,7 +29,7 @@ const handler = async ({ did, alias, profile }) => {
     choices.push({
       name: del.alias + '\t' + imported.issuer.did(),
       alias: del.alias,
-      value: imported.issuer.did(),
+      value: imported.issuer.did()
     })
   }
 
@@ -65,8 +64,8 @@ async function inquirerPick(choices, client) {
         type: 'list',
         name: 'Choose an account',
         choices,
-        default: client.settings.get('delegation'),
-      },
+        default: client.settings.get('delegation')
+      }
     ])
     .then((answers) => {
       const del = answers['Choose an account']
@@ -83,12 +82,12 @@ const builder = (yargs) =>
   yargs.check(hasID).option('did', {
     type: 'string',
     showInHelp: true,
-    describe: 'select account by did',
+    describe: 'select account by did'
   })
 
 export default {
   command: 'switch [alias]',
   describe: 'Select from delegations, including imported ones.',
   builder,
-  handler,
+  handler
 }

--- a/src/commands/delegations/to.js
+++ b/src/commands/delegations/to.js
@@ -1,8 +1,7 @@
-import fs from 'fs'
-import ora from 'ora'
-
 import { getClient } from '../../client.js'
 import { hasSetupAccount } from '../../validation.js'
+import fs from 'fs'
+import ora from 'ora'
 
 /**
  * @typedef {{did?:`did:${string}`, profile?: string}} Delegate
@@ -39,5 +38,5 @@ export default {
   command: 'to <did>',
   describe: 'Delegate permissions to another DID',
   builder,
-  handler,
+  handler
 }

--- a/src/commands/id.js
+++ b/src/commands/id.js
@@ -1,6 +1,5 @@
-import ora from 'ora'
-
 import { getClient, getProfileSettings } from '../client.js'
+import ora from 'ora'
 
 /**
  * @typedef {{reset?:boolean, profile?: string}} Id
@@ -34,7 +33,7 @@ const builder = (yargs) =>
     type: 'boolean',
     alias: 'reset',
     showInHelp: true,
-    describe: 'reset settings and generate id.',
+    describe: 'reset settings and generate id.'
   })
 
 export default {
@@ -43,5 +42,5 @@ export default {
   builder,
   handler,
   exampleOut: `ID loaded: did:key:z6MkiWm...`,
-  exampleIn: '$0 id',
+  exampleIn: '$0 id'
 }

--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -15,5 +15,5 @@ export default {
   builder: {},
   handler,
   exampleOut: ``,
-  exampleIn: '$0 info',
+  exampleIn: '$0 info'
 }

--- a/src/commands/insights.js
+++ b/src/commands/insights.js
@@ -1,9 +1,8 @@
+import { getClient } from '../client.js'
+import { hasSetupAccount, isCID } from '../validation.js'
 import * as API from '@ucanto/interface'
 import { parseLink } from '@ucanto/server'
 import ora from 'ora'
-
-import { getClient } from '../client.js'
-import { hasSetupAccount, isCID } from '../validation.js'
 
 /**
  * @typedef {{cid?:API.Link, ws?:boolean, subscribe?:boolean, insight_data?: any, profile?:string}} Insights
@@ -37,7 +36,7 @@ const builder = (yargs) =>
     type: 'boolean',
     alias: 'ws',
     showInHelp: true,
-    describe: 'Get a Subscription to incoming insights',
+    describe: 'Get a Subscription to incoming insights'
   })
 
 /**
@@ -51,5 +50,5 @@ export default {
   builder,
   handler,
   exampleOut: `example output goes here`,
-  exampleIn: '$0 insights',
+  exampleIn: '$0 insights'
 }

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -1,8 +1,7 @@
-import * as API from '@ucanto/interface'
-import open from 'open'
-
 import { OPEN_WITH_SERVICE_URL } from '../settings.js'
 import { isCID } from '../validation.js'
+import * as API from '@ucanto/interface'
+import open from 'open'
 
 /**
  * @typedef {{cid?:string}} Cid
@@ -46,5 +45,5 @@ export default {
   builder,
   handler,
   exampleIn: '$0 open bafy...',
-  exampleOut: `# opens ${OPEN_WITH_SERVICE_URL}/bafy... in your browser`,
+  exampleOut: `# opens ${OPEN_WITH_SERVICE_URL}/bafy... in your browser`
 }

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -1,8 +1,7 @@
-import ora from 'ora'
-
 import { getClient } from '../client.js'
 import { logToFile } from '../lib/logging.js'
 import { hasID, isEmail } from '../validation.js'
+import ora from 'ora'
 
 /**
  * @typedef {{email?:string, profile?: string}} Register
@@ -22,7 +21,7 @@ const handler = async (argv) => {
 
   const view = ora({
     text: `Registering ${email}, check your email for the link.`,
-    spinner: 'line',
+    spinner: 'line'
   }).start()
 
   try {
@@ -60,5 +59,5 @@ export default {
   command: 'register <email>',
   describe: 'Register your UCAN Identity with w3up',
   builder,
-  handler,
+  handler
 }

--- a/src/commands/settings/export.js
+++ b/src/commands/settings/export.js
@@ -1,10 +1,9 @@
+import { getClient } from '../../client.js'
+import { resolvePath } from '../../validation.js'
 import { exportSettings } from '@web3-storage/w3up-client'
 import fs from 'fs'
 import Inquirer from 'inquirer'
 import ora from 'ora'
-
-import { getClient } from '../../client.js'
-import { resolvePath } from '../../validation.js'
 
 /**
  * @typedef ExportSettings
@@ -38,11 +37,11 @@ const handler = async ({ filename, profile, stdout = false, yes = false }) => {
 
   if (!show) {
     view.stopAndPersist({
-      text: 'These values give anyone the power to act as you, are you sure you want to export them?',
+      text: 'These values give anyone the power to act as you, are you sure you want to export them?'
     })
     const input = await Inquirer.prompt({
       name: 'show',
-      type: 'confirm',
+      type: 'confirm'
     })
     show = input.show
   }
@@ -72,13 +71,13 @@ const builder = (yargs) =>
     .option('stdout', {
       type: 'boolean',
       showInHelp: true,
-      describe: 'Output a machine readable format to stdout',
+      describe: 'Output a machine readable format to stdout'
     })
     .option('yes', {
       type: 'boolean',
       alias: 'y',
       showInHelp: true,
-      describe: 'Skip any prompts with "yes" as input.',
+      describe: 'Skip any prompts with "yes" as input.'
     })
 
 export default {
@@ -87,5 +86,5 @@ export default {
   builder,
   handler,
   exampleOut: `DID:12345`,
-  exampleIn: '$0 export-settings',
+  exampleIn: '$0 export-settings'
 }

--- a/src/commands/settings/import.js
+++ b/src/commands/settings/import.js
@@ -1,11 +1,10 @@
 // @ts-ignore
+import { getClient } from '../../client.js'
+import { isPath } from '../../validation.js'
 import { importSettings } from '@web3-storage/w3up-client'
 import fs from 'fs'
 import Inquirer from 'inquirer'
 import ora from 'ora'
-
-import { getClient } from '../../client.js'
-import { isPath } from '../../validation.js'
 
 /**
  * @typedef ImportSettings
@@ -30,12 +29,12 @@ const handler = async ({ fileName, profile, yes = false }) => {
 
   if (!show) {
     spinner.stopAndPersist({
-      text: 'These values will overwrite your old id/account and you will lose access, are you sure you want to proceed?',
+      text: 'These values will overwrite your old id/account and you will lose access, are you sure you want to proceed?'
     })
 
     const input = await Inquirer.prompt({
       name: 'show',
-      type: 'confirm',
+      type: 'confirm'
     })
 
     show = input.show
@@ -69,7 +68,7 @@ const builder = (yargs) =>
     type: 'boolean',
     alias: 'y',
     showInHelp: true,
-    describe: 'Skip any prompts with "yes" as input.',
+    describe: 'Skip any prompts with "yes" as input.'
   })
 
 /**
@@ -85,5 +84,5 @@ export default {
   builder,
   handler,
   exampleOut: `You have successfully imported settings.json!`,
-  exampleIn: '$0 import-settings settings.json',
+  exampleIn: '$0 import-settings settings.json'
 }

--- a/src/commands/settings/index.js
+++ b/src/commands/settings/index.js
@@ -8,5 +8,5 @@ export default {
   handler: () => {},
   // @ts-expect-error
   builder: (yargs) =>
-    yargs.command([exportSettings, importSettings, resetSettings]),
+    yargs.command([exportSettings, importSettings, resetSettings])
 }

--- a/src/commands/settings/reset.js
+++ b/src/commands/settings/reset.js
@@ -1,7 +1,6 @@
+import { getClient } from '../../client.js'
 import Inquirer from 'inquirer'
 import ora from 'ora'
-
-import { getClient } from '../../client.js'
 
 /**
  * @typedef {{profile?: string}} ResetSettings
@@ -18,7 +17,7 @@ const handler = async (args) => {
     text: `This will delete your settings, are you sure?
   You will lose access to anything created with your previous key/did.
   If you want to keep the previous settings, use export-settings first.
-`,
+`
   })
 
   const client = getClient(args.profile)
@@ -26,7 +25,7 @@ const handler = async (args) => {
   const { reset } = await Inquirer.prompt({
     name: 'reset',
     type: 'confirm',
-    default: false,
+    default: false
   })
 
   if (reset) {
@@ -43,5 +42,5 @@ export default {
   builder: {},
   handler,
   exampleOut: `Settings cleared.`,
-  exampleIn: '$0 reset-settings',
+  exampleIn: '$0 reset-settings'
 }

--- a/src/commands/store/index.js
+++ b/src/commands/store/index.js
@@ -6,5 +6,5 @@ export default {
   describe: 'Manage car files in w3up.',
   handler: () => {},
   // @ts-expect-error
-  builder: (yargs) => yargs.command([list, remove]),
+  builder: (yargs) => yargs.command([list, remove])
 }

--- a/src/commands/store/list.js
+++ b/src/commands/store/list.js
@@ -1,8 +1,7 @@
-import ora, { oraPromise } from 'ora'
-
 import { getClient } from '../../client.js'
 import { buildSimpleConsoleTable, humanizeBytes } from '../../utils.js'
 import { hasSetupAccount } from '../../validation.js'
+import ora, { oraPromise } from 'ora'
 
 /**
  * @typedef {{verbose?:boolean, delim?:string, stdout?:boolean, profile?: string}} List
@@ -38,7 +37,7 @@ function itemToTable(item, verbose = false) {
     uploadedAt = new Intl.DateTimeFormat('en-US', {
       month: '2-digit',
       day: '2-digit',
-      year: 'numeric',
+      year: 'numeric'
     })
       .format(Date.parse(at))
       .toLocaleString()
@@ -102,7 +101,7 @@ const handler = async (argv) => {
   /** @type any */
   const listResponse = await oraPromise(client.stat(), {
     text: `Listing linked cars...`,
-    spinner: 'line',
+    spinner: 'line'
   })
 
   if (!listResponse?.results?.length) {
@@ -123,13 +122,13 @@ const builder = (yargs) =>
     .option('stdout', {
       type: 'boolean',
       showInHelp: true,
-      describe: 'Output a machine readable format to stdout',
+      describe: 'Output a machine readable format to stdout'
     })
     .option('delim', {
       type: 'string',
       showInHelp: true,
       implies: 'stdout',
-      describe: 'The delimiter to use when using stdout',
+      describe: 'The delimiter to use when using stdout'
     })
 
 export default {
@@ -138,5 +137,5 @@ export default {
   builder,
   handler,
   exampleOut: `bafy...\nbafy...`,
-  exampleIn: '$0 list',
+  exampleIn: '$0 list'
 }

--- a/src/commands/store/remove.js
+++ b/src/commands/store/remove.js
@@ -1,10 +1,9 @@
+import { getClient } from '../../client.js'
+import { hasID, hasSetupAccount, isCID } from '../../validation.js'
 import * as API from '@ucanto/interface'
 // @ts-ignore
 import { parseLink } from '@ucanto/server'
 import ora from 'ora'
-
-import { getClient } from '../../client.js'
-import { hasID, hasSetupAccount, isCID } from '../../validation.js'
 
 /**
  * @typedef {{cid?:API.Link, profile?:string}} Remove
@@ -44,5 +43,5 @@ export default {
   builder,
   handler,
   exampleIn: '$0 remove bafy...',
-  exampleOut: `unlinked bafy...`,
+  exampleOut: `unlinked bafy...`
 }

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -1,3 +1,8 @@
+import { getClient } from '../client.js'
+import { buildCar } from '../lib/car/buildCar.js'
+import { logToFile } from '../lib/logging.js'
+import { bytesToCarCID } from '../utils.js'
+import { checkPath, hasID, hasSetupAccount } from '../validation.js'
 import fs from 'fs'
 // @ts-ignore
 import { CID } from 'multiformats/cid'
@@ -5,12 +10,6 @@ import ora from 'ora'
 import path from 'path'
 // @ts-ignore
 import toIterator from 'stream-to-it'
-
-import { getClient } from '../client.js'
-import { buildCar } from '../lib/car/buildCar.js'
-import { logToFile } from '../lib/logging.js'
-import { bytesToCarCID } from '../utils.js'
-import { checkPath, hasID, hasSetupAccount } from '../validation.js'
 
 /**
  * @typedef {{path?: string, split?: boolean, profile?: string}} Upload
@@ -104,14 +103,13 @@ const builder = (yargs) =>
     .check(hasSetupAccount)
     .check(checkPath)
     .option('chunk-size', {
-      type: 'number',
+      type: 'number'
     })
     .option('split', {
       type: 'boolean',
       alias: 'split',
       showInHelp: true,
-      describe:
-        'Split the data into multiple when cars when size limit is hit.',
+      describe: 'Split the data into multiple when cars when size limit is hit.'
     })
 
 export default {
@@ -121,5 +119,5 @@ export default {
   builder,
   handler,
   exampleIn: '$0 upload ../../duck.png',
-  exampleOut: `uploaded bafy...`,
+  exampleOut: `uploaded bafy...`
 }

--- a/src/commands/uploadCars.js
+++ b/src/commands/uploadCars.js
@@ -1,11 +1,4 @@
 // @ts-expect-error
-import * as CAR from '@ipld/car'
-import fs from 'fs'
-import ora from 'ora'
-import path from 'path'
-// @ts-ignore
-import toIterator from 'stream-to-it'
-
 import { getClient } from '../client.js'
 import { getAllFiles, isDirectory } from '../lib/car/file.js'
 import { logToFile } from '../lib/logging.js'
@@ -16,8 +9,14 @@ import {
   hasID,
   hasSetupAccount,
   isCarFile,
-  resolvePath,
+  resolvePath
 } from '../validation.js'
+import * as CAR from '@ipld/car'
+import fs from 'fs'
+import ora from 'ora'
+import path from 'path'
+// @ts-ignore
+import toIterator from 'stream-to-it'
 
 //gotta start somewhere. 3 is fine.
 const MAX_CONNECTION_POOL_SIZE = 3
@@ -67,7 +66,7 @@ const handler = async (argv) => {
   const _path = argv.path
   const view = ora({
     text: `Uploading ${_path}...`,
-    spinner: 'line',
+    spinner: 'line'
   }).start()
 
   const client = getClient(argv.profile)
@@ -126,5 +125,5 @@ export default {
   builder,
   handler,
   exampleIn: '$0 upload-cars ducks/',
-  exampleOut: `<show all cars uploaded>`,
+  exampleOut: `<show all cars uploaded>`
 }

--- a/src/commands/uploads/index.js
+++ b/src/commands/uploads/index.js
@@ -9,6 +9,6 @@ export default {
   builder: (yargs) =>
     yargs.command([list, remove]).command({
       ...list,
-      command: '*',
-    }),
+      command: '*'
+    })
 }

--- a/src/commands/uploads/list.js
+++ b/src/commands/uploads/list.js
@@ -1,8 +1,7 @@
-import ora, { oraPromise } from 'ora'
-
 import { getClient } from '../../client.js'
 import { buildSimpleConsoleTable } from '../../utils.js'
 import { hasSetupAccount } from '../../validation.js'
+import ora, { oraPromise } from 'ora'
 
 /**
  * @typedef {{verbose?:boolean, delim?:string, stdout?:boolean, profile?: string}} List
@@ -34,7 +33,7 @@ function parseDate(date) {
   return new Intl.DateTimeFormat('en-US', {
     month: '2-digit',
     day: '2-digit',
-    year: 'numeric',
+    year: 'numeric'
   })
     .format(date)
     .toLocaleString()
@@ -104,7 +103,7 @@ const handler = async (argv) => {
   /** @type any */
   const listResponse = await oraPromise(client.list(), {
     text: `Listing Uploads...`,
-    spinner: 'line',
+    spinner: 'line'
   })
 
   if (!listResponse?.results?.length) {
@@ -126,18 +125,18 @@ const builder = (yargs) =>
       type: 'boolean',
       alias: 'verbose',
       showInHelp: true,
-      describe: 'Show more columns in the list, such as the Uploaded CAR CID',
+      describe: 'Show more columns in the list, such as the Uploaded CAR CID'
     })
     .option('stdout', {
       type: 'boolean',
       showInHelp: true,
-      describe: 'Output a machine readable format to stdout',
+      describe: 'Output a machine readable format to stdout'
     })
     .option('delim', {
       type: 'string',
       showInHelp: true,
       implies: 'stdout',
-      describe: 'The delimiter to use when using stdout',
+      describe: 'The delimiter to use when using stdout'
     })
 
 export default {
@@ -146,5 +145,5 @@ export default {
   builder,
   handler,
   exampleOut: `bafy...\nbafy...`,
-  exampleIn: '$0 list',
+  exampleIn: '$0 list'
 }

--- a/src/commands/uploads/remove.js
+++ b/src/commands/uploads/remove.js
@@ -1,10 +1,9 @@
+import { getClient } from '../../client.js'
+import { hasID, hasSetupAccount, isCID } from '../../validation.js'
 import * as API from '@ucanto/interface'
 // @ts-ignore
 import { parseLink } from '@ucanto/server'
 import ora from 'ora'
-
-import { getClient } from '../../client.js'
-import { hasID, hasSetupAccount, isCID } from '../../validation.js'
 
 /**
  * @typedef {{cid?:API.Link, profile?:string}} Remove
@@ -44,5 +43,5 @@ export default {
   builder,
   handler,
   exampleIn: '$0 remove bafy...',
-  exampleOut: `unlinked bafy...`,
+  exampleOut: `unlinked bafy...`
 }

--- a/src/commands/whoami.js
+++ b/src/commands/whoami.js
@@ -1,7 +1,6 @@
-import ora from 'ora'
-
 import { getClient } from '../client.js'
 import { hasSetupAccount } from '../validation.js'
+import ora from 'ora'
 
 /**
  * @typedef {{profile?: string}} WhoAmI
@@ -48,5 +47,5 @@ export default {
   builder,
   handler,
   exampleOut: `DID:12345...`,
-  exampleIn: '$0 whoami',
+  exampleIn: '$0 whoami'
 }

--- a/src/lib/car/buildCar.js
+++ b/src/lib/car/buildCar.js
@@ -1,13 +1,12 @@
 // @ts-ignore
+import { isDirectory } from '../../utils.js'
+import { walkDir, wrapFilesWithDir } from './dir.js'
+import { streamFileToBlock } from './file.js'
 import * as CAR from '@ipld/car'
 import * as UnixFS from '@ipld/unixfs'
 import fs from 'fs'
 import path from 'path'
 import 'web-streams-polyfill'
-
-import { isDirectory } from '../../utils.js'
-import { walkDir, wrapFilesWithDir } from './dir.js'
-import { streamFileToBlock } from './file.js'
 
 // Internal unixfs read stream capacity that can hold around 32 blocks
 const CAPACITY = UnixFS.BLOCK_SIZE_LIMIT * 32
@@ -46,7 +45,7 @@ async function createReadableBlockStreamWithWrappingDir(pathName, writable) {
         await walkDir({
           writer,
           pathName: pathName,
-          filename: name,
+          filename: name
         })
       )
     }
@@ -91,10 +90,10 @@ export async function buildCar(pathName, carsize, failAtSplit = false) {
   let carWriterStream = new TransformStream(
     {},
     {
-      highWaterMark: MAX_CARS_AT_ONCE,
+      highWaterMark: MAX_CARS_AT_ONCE
     },
     {
-      highWaterMark: MAX_CARS_AT_ONCE,
+      highWaterMark: MAX_CARS_AT_ONCE
     }
   )
   let carStreamWriter = carWriterStream.writable.getWriter()
@@ -147,6 +146,6 @@ export async function buildCar(pathName, carsize, failAtSplit = false) {
   readAll()
 
   return {
-    stream: carWriterStream.readable,
+    stream: carWriterStream.readable
   }
 }

--- a/src/lib/car/dir.js
+++ b/src/lib/car/dir.js
@@ -1,9 +1,8 @@
+import { isDirectory } from '../../utils.js'
+import { streamFileToBlock } from './file.js'
 import * as UnixFS from '@ipld/unixfs'
 import fs from 'fs'
 import path from 'path'
-
-import { isDirectory } from '../../utils.js'
-import { streamFileToBlock } from './file.js'
 
 /** @typedef {{name: string, link: any}} FileDesc */
 
@@ -29,14 +28,14 @@ export async function walkDir({ writer, pathName, filename }) {
         await walkDir({
           writer,
           pathName: pathName + '/' + filename,
-          filename: name,
+          filename: name
         })
       )
     }
     return wrapFilesWithDir({
       writer,
       files,
-      dirName: filename,
+      dirName: filename
     })
   }
 
@@ -58,6 +57,6 @@ export async function wrapFilesWithDir({ writer, files, dirName = '' }) {
 
   return {
     name: dirName,
-    link: dirLink,
+    link: dirLink
   }
 }

--- a/src/lib/car/file.js
+++ b/src/lib/car/file.js
@@ -19,7 +19,7 @@ export async function fileToBlock({ writer, filename, bytes }) {
 
   return {
     name: filename,
-    link,
+    link
   }
 }
 
@@ -43,7 +43,7 @@ export async function streamFileToBlock({ writer, filePath }) {
 
   return {
     name: path.basename(filePath),
-    link,
+    link
   }
 }
 /**

--- a/src/lib/info/carToDot.js
+++ b/src/lib/info/carToDot.js
@@ -1,8 +1,7 @@
-import { CarIndexer } from '@ipld/car/indexer'
-import { CarReader } from '@ipld/car/reader'
-
 import { humanizeBytes } from '../../utils.js'
 import { codecNames, decode, nodeTypeNames, toShortCID } from './common.js'
+import { CarIndexer } from '@ipld/car/indexer'
+import { CarReader } from '@ipld/car/reader'
 
 const ignoredKeysForLabel = ['blockLength', 'offset', 'blockOffset']
 
@@ -63,7 +62,7 @@ export async function run(bytes, vertical) {
   /** @type {{roots:Array<any>, blocks:any}} */
   const fixture = {
     roots: reader._header.roots, // a little naughty but we need gory details
-    blocks: [],
+    blocks: []
   }
 
   let dot = `digraph { 

--- a/src/lib/info/carToList.js
+++ b/src/lib/info/carToList.js
@@ -1,7 +1,6 @@
+import { toOutput } from './common.js'
 import { CarIndexer } from '@ipld/car/indexer'
 import { CarReader } from '@ipld/car/reader'
-
-import { toOutput } from './common.js'
 
 /**
  * @async

--- a/src/lib/info/carToTree.js
+++ b/src/lib/info/carToTree.js
@@ -1,9 +1,8 @@
+import { decode } from './common.js'
 import { CarIndexer } from '@ipld/car/indexer'
 import { CarReader } from '@ipld/car/reader'
 // @ts-ignore
 import archy from 'archy'
-
-import { decode } from './common.js'
 
 // @ts-ignore
 /** @typedef {import('multiformats/cid').CID} CID */
@@ -24,7 +23,7 @@ export async function run(bytes) {
   /** @type TreeNode */
   let output = {
     label: 'roots',
-    nodes: [],
+    nodes: []
   }
 
   /** @type Array<Block> */
@@ -46,13 +45,13 @@ export async function run(bytes) {
 
     blockMap.set(blockIndex.cid.toString(), {
       cid: blockIndex.cid.toString(),
-      links: links,
+      links: links
     })
 
     if (isRoot) {
       contentRoots.push({
         cid: blockIndex.cid.toString(),
-        links: links,
+        links: links
       })
     }
   }
@@ -85,6 +84,6 @@ function walkTree(cid, name, blockMap) {
       .map((x) =>
         walkTree(x.cid.toString(), x?.name || x?.Name || '', blockMap)
       )
-      .filter((x) => x),
+      .filter((x) => x)
   }
 }

--- a/src/lib/info/common.js
+++ b/src/lib/info/common.js
@@ -19,7 +19,7 @@ export const codecs = {
   [dagPb.code]: dagPb,
   [dagJson.code]: dagJson,
   [raw.code]: raw,
-  [json.code]: json,
+  [json.code]: json
 }
 
 export const codecNames = {
@@ -27,7 +27,7 @@ export const codecNames = {
   [dagPb.code]: 'dagPb',
   [dagJson.code]: 'dagJson',
   [raw.code]: 'raw',
-  [json.code]: 'json',
+  [json.code]: 'json'
   //   [0x202]: 'car',
 }
 
@@ -37,7 +37,7 @@ export const nodeTypeNames = {
   [UnixFS.NodeType.HAMTShard]: 'hamt',
   [UnixFS.NodeType.Metadata]: 'meta',
   [UnixFS.NodeType.Raw]: 'raw',
-  [UnixFS.NodeType.Symlink]: 'sym',
+  [UnixFS.NodeType.Symlink]: 'sym'
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,3 @@
-import _yargs from 'yargs'
-import { hideBin } from 'yargs/helpers'
-
 import car from './commands/car/index.js'
 import delegations from './commands/delegations/index.js'
 import id from './commands/id.js'
@@ -16,6 +13,8 @@ import uploads from './commands/uploads/index.js'
 import list from './commands/uploads/list.js'
 import whoami from './commands/whoami.js'
 import printQuickstart from './quickstart.js'
+import _yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
 
 /**
  * @type {import('yargs').Argv<{}>} yargs
@@ -30,7 +29,7 @@ export const main = async () => {
       alias: 'profile',
       type: 'string',
       describe: 'Select profile.',
-      default: 'main',
+      default: 'main'
     })
     .group('profile', 'Global:')
     .command({
@@ -38,13 +37,13 @@ export const main = async () => {
       handler() {
         printQuickstart()
         yargs.showHelp()
-      },
+      }
     })
     .command({
       command: 'completion',
       handler() {
         yargs.showCompletionScript()
-      },
+      }
     })
 
     //registration

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,7 +1,6 @@
+import { humanizeBytes } from './utils.js'
 import * as API from '@ucanto/interface'
 import { config } from 'dotenv'
-
-import { humanizeBytes } from './utils.js'
 
 config()
 
@@ -35,5 +34,5 @@ export default {
   ACCESS_DID,
   ACCESS_URL,
   MAX_CAR_SIZE,
-  MAX_CAR_SIZE_HUMANIZED: humanizeBytes(MAX_CAR_SIZE),
+  MAX_CAR_SIZE_HUMANIZED: humanizeBytes(MAX_CAR_SIZE)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,9 +74,9 @@ export function buildSimpleConsoleTable(head) {
       'mid-mid': '',
       right: '',
       'right-mid': '',
-      middle: ' ',
+      middle: ' '
     },
-    style: { 'padding-left': 0, 'padding-right': 2, head: ['blue'] },
+    style: { 'padding-left': 0, 'padding-right': 2, head: ['blue'] }
   })
 
   table.push(new Array(head.length).fill('--------'))

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,11 +1,10 @@
+import { getProfileSettings } from './client.js'
 import * as API from '@ucanto/interface'
 // @ts-ignore
 import { parseLink } from '@ucanto/server'
 import fs from 'fs'
 import path from 'path'
 import { pathToFileURL } from 'url'
-
-import { getProfileSettings } from './client.js'
 
 /**
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -4224,6 +4224,11 @@ postcss@^8.4.16:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prettier-config-standard@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-config-standard/-/prettier-config-standard-5.0.0.tgz#c99dbef099412eda0876f75fdc1732ffef2ab0e0"
+  integrity sha512-QK252QwCxlsak8Zx+rPKZU31UdbRcu9iUk9X1ONYtLSO221OgvV9TlKoTf6iPDZtvF3vE2mkgzFIEgSUcGELSQ==
+
 prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"


### PR DESCRIPTION
This sets up prettier standard config with latest main, fixed existing issues running prettier fix.

This is not a replacement for the linter, but a code formatting tool to help catch and correct non-standardjs compliant code.